### PR TITLE
feat: use git patches instead of local paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,24 @@
 [workspace]
 members = ["bridge", "runtime", "shared", "tests"]
 default-members = ["bridge", "runtime", "shared", "tests"]
+
+[patch.crates-io]
+fvm = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
+fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
+fvm_ipld_encoding = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
+fvm_ipld_blockstore = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
+fvm_sdk = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
+fvm_ipld_hamt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
+fvm_ipld_amt = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
+fvm_ipld_car = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
+
+#[patch.crates-io]
+#fvm = { path = "../../ref-fvm/fvm" }
+#fvm_shared = { path = "../../ref-fvm/shared" }
+#fvm_ipld_encoding = { path = "../../ref-fvm/ipld/encoding" }
+#fvm_ipld_blockstore = { path = "../../ref-fvm/ipld/blockstore" }
+#fvm_integration_tests = { path = "../../ref-fvm/testing/integration" }
+#fil_actors_runtime = { path = "../../builtin-actors/runtime" }
+#fvm_sdk = { path = "../../ref-fvm/sdk" }
+#fvm_ipld_hamt = { path = "../../ref-fvm/ipld/hamt" }
+#fvm_ipld_amt = { path = "../../ref-fvm/ipld/amt" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["bridge", "runtime", "shared", "tests"]
 default-members = ["bridge", "runtime", "shared", "tests"]
 

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -10,16 +10,12 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 doctest = false
 
 [dependencies]
-fvm_ipld_blockstore = { path = "../../ref-fvm/ipld/blockstore" }
-fvm_ipld_encoding = { path = "../../ref-fvm/ipld/encoding" }
-fvm_ipld_hamt = { path = "../../ref-fvm/ipld/hamt" }
-fvm_sdk = { path = "../../ref-fvm/sdk" }
-fvm_shared = { path = "../../ref-fvm/shared", default-features = false }
-
-fil_actors_runtime = { path = "../../builtin-actors/runtime", features = [
-  "fil-actor",
-] }
-
+fvm_ipld_blockstore = "0.1.1"
+fvm_ipld_encoding = "0.2.2"
+fvm_ipld_hamt = "0.5.1"
+fvm_sdk = "1.0.0-rc.3"
+fvm_shared = { version = "0.8.0", default-features = false }
+fil_actors_runtime = { git = "https://github.com/filecoin-project/builtin-actors", features = ["fil-actor"] }
 fvm-evm = { path = "../shared" }
 
 cid = { version = "0.8.5", default-features = false }

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -31,13 +31,11 @@ rlp = { version = "0.5.1", default-features = false }
 
 [build-dependencies]
 wasm-builder = "3.0.1"
-wasmtime = "0.37"
 
 [dev-dependencies]
 rand = "0.8"
 rand_chacha = "0.3"
 anyhow = "1.0.52"
-wasmtime = "0.37.0"
 hex = "0.4.3"
 
 [features]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -29,14 +29,12 @@ fil_actors_runtime = { git = "https://github.com/filecoin-project/builtin-actors
 
 [build-dependencies]
 wasm-builder = "3.0.1"
-wasmtime = "0.37"
 
 [dev-dependencies]
 libsecp256k1 = { version = "0.7" }
 rand = "0.8"
 rand_chacha = "0.3"
 anyhow = "1.0.52"
-wasmtime = "0.37.0"
 
 [features]
 default = ["fil-actor"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,18 +10,7 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 doctest = false
 
 [dependencies]
-fvm_ipld_blockstore = { path = "../../ref-fvm/ipld/blockstore" }
-fvm_ipld_encoding = { path = "../../ref-fvm/ipld/encoding" }
-fvm_ipld_hamt = { path = "../../ref-fvm/ipld/hamt" }
-fvm_sdk = { path = "../../ref-fvm/sdk" }
-fvm_shared = { path = "../../ref-fvm/shared", default-features = false }
-
-fil_actors_runtime = { path = "../../builtin-actors/runtime", features = [
-  "fil-actor",
-] }
-
 fvm-evm = { path = "../shared", default-features = false }
-
 anyhow = "1"
 cid = { version = "0.8.5", default-features = false }
 multihash = { version = "0.16.2", default-features = false }
@@ -30,6 +19,12 @@ serde_tuple = "0.5"
 bytes = { version = "1.1.0", default-features = false }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
+fvm_ipld_blockstore = "0.1.1"
+fvm_ipld_encoding = "0.2.2"
+fvm_ipld_hamt = "0.5.1"
+fvm_sdk = "1.0.0-rc.3"
+fvm_shared = { version = "0.8.0", default-features = false }
+fil_actors_runtime = { git = "https://github.com/filecoin-project/builtin-actors", features = ["fil-actor"] }
 
 
 [build-dependencies]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,16 +10,6 @@ keywords = ["filecoin", "web3", "wasm", "evm"]
 doctest = false
 
 [dependencies]
-fvm_ipld_blockstore = { path = "../../ref-fvm/ipld/blockstore" }
-fvm_ipld_encoding = { path = "../../ref-fvm/ipld/encoding" }
-fvm_ipld_hamt = { path = "../../ref-fvm/ipld/hamt" }
-fvm_sdk = { path = "../../ref-fvm/sdk" }
-fvm_shared = { path = "../../ref-fvm/shared", default-features = false }
-
-fil_actors_runtime = { path = "../../builtin-actors/runtime", features = [
-  "fil-actor",
-] }
-
 anyhow = "1"
 serde_tuple = "0.5"
 serde = { version = "1.0", features = ["derive"] }
@@ -34,10 +24,14 @@ strum = "0.24"
 strum_macros = "0.24"
 sha3 = { version = "0.10", default-features = false }
 rlp = { version = "0.5.1", default-features = false }
+fvm_ipld_blockstore = "0.1.1"
+fvm_ipld_encoding = "0.2.2"
+fvm_ipld_hamt = "0.5.1"
+fvm_sdk = "1.0.0-rc.3"
+fvm_shared = { version = "0.8.0", default-features = false }
+fil_actors_runtime = { git = "https://github.com/filecoin-project/builtin-actors", features = ["fil-actor"] }
 
 [dev-dependencies]
 libsecp256k1 = { version = "0.7.0", features = ["static-context"] }
 hex-literal = "0.3.4"
-fvm_shared = { path = "../../ref-fvm/shared", default-features = false, features = [
-  "crypto",
-] }
+fvm_shared = { version = "0.8.0", default-features = false, features = ["crypto"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,15 +17,15 @@ serde = { version = "1.0", features = ["derive"] }
 cid = { version = "0.8.5", default-features = false }
 libsecp256k1 = { version = "0.7.0", features = ["static-context"] }
 fvm-evm = { path = "../shared" }
-
-fvm = { path = "../../ref-fvm/fvm", default-features = false }
-fvm_shared = { path = "../../ref-fvm/shared" }
-fvm_ipld_encoding = { path = "../../ref-fvm/ipld/encoding" }
-fvm_ipld_blockstore = { path = "../../ref-fvm/ipld/blockstore" }
-fvm_integration_tests = { path = "../../ref-fvm/testing/integration" }
-
 log = "0.4"
 pretty_env_logger = "0.4"
+fvm_ipld_blockstore = "0.1.1"
+fvm_ipld_encoding = "0.2.2"
+fvm_shared = { version = "0.8.0" }
+fvm = { version = "1.0.0-rc.3", default-features = false }
+# We should do this with a patch, but we can't because it's not published to crates.io and
+# https://github.com/rust-lang/cargo/issues/5478
+fvm_integration_tests = { git = "https://github.com/filecoin-project/ref-fvm", branch = "karim/recover-pubkey-syscall" }
 
 [dependencies.wasmtime]
 version = "0.37.0"


### PR DESCRIPTION
This makes it possible for anyone to build and test without having to checkout the FVM and builtin actors locally, and apply a bunch of manual patches.